### PR TITLE
feat: implement board view layout and routing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { CssBaseline, Box } from '@mui/material';
 import Navbar from './components/Navbar';
 import LoginPage from './pages/LoginPage';
-import BoardsPage from './pages/BoardsList';
+import BoardsList from './pages/BoardsList';
 import BoardViewPage from './pages/BoardViewPage';
 
 function App() {
@@ -17,8 +17,8 @@ function App() {
           <Route path="/" element={<Navigate to="/login" />} />
           
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/boards" element={<BoardsPage />} />
-          <Route path="/boards/:id" element={<BoardViewPage />} />
+          <Route path="/boards" element={<BoardsList />} />
+          <Route path="/board/:id" element={<BoardViewPage />} />
         </Routes>
       </Box>
     </BrowserRouter>

--- a/frontend/src/pages/BoardViewPage.jsx
+++ b/frontend/src/pages/BoardViewPage.jsx
@@ -1,10 +1,276 @@
-import { Box, Typography } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { 
+  Box, 
+  Card, 
+  CardContent, 
+  Typography, 
+  Button, 
+  Container,
+  Skeleton,
+  Chip,
+  IconButton,
+  Stack
+} from '@mui/material';
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import AddIcon from '@mui/icons-material/Add';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import { useNavigate } from 'react-router-dom';
 
-export default function BoardViewPage() {
+// --- MOCK DATA ---
+const MOCK_DATA = [
+  { 
+    id: 'board-1', 
+    title: 'Marketing Campaign', 
+    status: 'Planning', 
+    color: '#00b0ff',
+    items: [
+      { id: 'task-1', content: 'Draft social media copy', priority: 'High', due: '2 days' },
+      { id: 'task-2', content: 'Select stock images', priority: 'Medium', due: '4 days' }
+    ]
+  },
+  { 
+    id: 'board-2', 
+    title: 'Design System', 
+    status: 'In Progress', 
+    color: '#00c853',
+    items: [
+      { id: 'task-3', content: 'Update button components', priority: 'High', due: 'Today' },
+      { id: 'task-4', content: 'Review typography scale', priority: 'Low', due: '1 week' },
+      { id: 'task-5', content: 'Fix mobile responsiveness', priority: 'High', due: 'Tomorrow' }
+    ]
+  },
+  { 
+    id: 'board-3', 
+    title: 'Tasky Roadmap', 
+    status: 'Active', 
+    color: '#6200ea',
+    items: [] 
+  },
+];
+
+// --- 1. NEW: PRIORITY COLOR MAP ---
+const PRIORITY_STYLES = {
+  High: { color: '#d32f2f', bgcolor: '#ffebee' },    // Red
+  Medium: { color: '#ed6c02', bgcolor: '#fff3e0' },  // Orange
+  Low: { color: '#2e7d32', bgcolor: '#e8f5e9' }      // Green
+};
+
+const BoardViewPage = () => {
+  const [columns, setColumns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setTimeout(() => {
+      setColumns(MOCK_DATA); 
+      setLoading(false);
+    }, 1500); 
+  }, []);
+
+  const onDragEnd = (result) => {
+    if (!result.destination) return; 
+
+    const { source, destination } = result;
+
+    const sourceColIndex = columns.findIndex(col => col.id === source.droppableId);
+    const destColIndex = columns.findIndex(col => col.id === destination.droppableId);
+    
+    const sourceCol = columns[sourceColIndex];
+    const destCol = columns[destColIndex];
+
+    const sourceItems = [...sourceCol.items];
+    const destItems = [...destCol.items];
+
+    const [removed] = sourceItems.splice(source.index, 1);
+
+    if (source.droppableId === destination.droppableId) {
+      sourceItems.splice(destination.index, 0, removed);
+      const newColumns = [...columns];
+      newColumns[sourceColIndex] = { ...sourceCol, items: sourceItems };
+      setColumns(newColumns);
+    } else {
+      destItems.splice(destination.index, 0, removed);
+      const newColumns = [...columns];
+      newColumns[sourceColIndex] = { ...sourceCol, items: sourceItems };
+      newColumns[destColIndex] = { ...destCol, items: destItems };
+      setColumns(newColumns);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Container maxWidth={false} sx={{ mt: 4, px: 4 }}>
+        <Box mb={4}><Skeleton variant="rectangular" width={200} height={40} /></Box>
+        <Box display="flex" gap={3} overflow="hidden">
+          {[1, 2, 3].map((item) => (
+            <Skeleton key={item} variant="rectangular" width={320} height={400} sx={{ borderRadius: 3, flexShrink: 0 }} />
+          ))}
+        </Box>
+      </Container>
+    );
+  }
+
   return (
-    <Box sx={{ p: 4 }}>
-      <Typography variant="h4">Kanban Board View</Typography>
-      <Typography>Columns and drag-and-drop will go here.</Typography>
-    </Box>
+    <Container maxWidth={false} sx={{ mt: 4, mb: 8, height: '85vh', display: 'flex', flexDirection: 'column' }}>
+      
+      <Box mb={3}>
+        <Typography variant="h4" fontWeight="800" sx={{ letterSpacing: '-1px' }}>
+          My Boards
+        </Typography>
+      </Box>
+
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Box 
+          sx={{ 
+            display: 'flex', 
+            gap: 3, 
+            overflowX: 'auto', 
+            pb: 2, 
+            height: '100%',
+            alignItems: 'flex-start',
+            '&::-webkit-scrollbar': { height: '8px' },
+            '&::-webkit-scrollbar-track': { background: '#f1f1f1' },
+            '&::-webkit-scrollbar-thumb': { background: '#ccc', borderRadius: '4px' },
+          }}
+        >
+          {columns.map((column) => (
+            <Box 
+              key={column.id}
+              sx={{ 
+                minWidth: '320px', 
+                maxWidth: '320px', 
+                bgcolor: '#f4f5f7', 
+                borderRadius: '12px', 
+                p: 2,
+                flexShrink: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                maxHeight: '100%'
+              }}
+            >
+              <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Typography fontWeight="bold" variant="subtitle1">{column.title}</Typography>
+                  <Chip 
+                    label={column.items.length} 
+                    size="small" 
+                    sx={{ height: 20, fontSize: '0.7rem', fontWeight: 'bold', bgcolor: 'rgba(0,0,0,0.08)' }} 
+                  />
+                </Box>
+                <IconButton size="small"><MoreVertIcon fontSize="small" /></IconButton>
+              </Box>
+
+              <Droppable droppableId={column.id}>
+                {(provided, snapshot) => (
+                  <Box
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    sx={{ 
+                      flexGrow: 1, 
+                      minHeight: '100px',
+                      transition: 'background-color 0.2s ease',
+                      bgcolor: snapshot.isDraggingOver ? 'rgba(0,0,0,0.05)' : 'transparent',
+                      borderRadius: '8px'
+                    }}
+                  >
+                    {column.items.map((task, index) => (
+                      <Draggable key={task.id} draggableId={task.id} index={index}>
+                        {(provided, snapshot) => (
+                          <Card 
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            {...provided.dragHandleProps}
+                            onClick={() => navigate(`/task/${task.id}`)}
+                            sx={{ 
+                              mb: 2, 
+                              borderRadius: '8px', 
+                              boxShadow: snapshot.isDragging ? '0 10px 20px rgba(0,0,0,0.15)' : '0 1px 3px rgba(0,0,0,0.12)',
+                              cursor: 'grab',
+                              transition: 'transform 0.2s',
+                              transform: snapshot.isDragging ? 'rotate(3deg)' : 'none',
+                              '&:hover': { boxShadow: '0 4px 8px rgba(0,0,0,0.1)' }
+                            }}
+                          >
+                            <CardContent sx={{ p: '16px !important' }}>
+                              <Typography variant="body2" fontWeight="600" gutterBottom>
+                                {task.content}
+                              </Typography>
+                              
+                              <Stack direction="row" justifyContent="space-between" alignItems="center" mt={1}>
+                                
+                                {/* --- 2. UPDATED CHIP LOGIC HERE --- */}
+                                <Chip 
+                                  label={task.priority} 
+                                  size="small" 
+                                  sx={{ 
+                                    height: '20px', 
+                                    fontSize: '0.65rem', 
+                                    fontWeight: 'bold',
+                                    color: PRIORITY_STYLES[task.priority]?.color || 'grey',
+                                    bgcolor: PRIORITY_STYLES[task.priority]?.bgcolor || '#f5f5f5'
+                                  }} 
+                                />
+
+                                <Typography variant="caption" color="text.secondary" display="flex" alignItems="center">
+                                  <AccessTimeIcon sx={{ fontSize: 14, mr: 0.5 }} />
+                                  {task.due}
+                                </Typography>
+                              </Stack>
+                            </CardContent>
+                          </Card>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                  </Box>
+                )}
+              </Droppable>
+
+              <Button 
+                startIcon={<AddIcon />} 
+                fullWidth
+                sx={{ 
+                  justifyContent: 'flex-start', 
+                  color: 'text.secondary', 
+                  textTransform: 'none',
+                  mt: 1,
+                  '&:hover': { bgcolor: 'rgba(0,0,0,0.05)', color: 'black' } 
+                }}
+              >
+                Add a task
+              </Button>
+
+            </Box>
+          ))}
+
+          <Box sx={{ minWidth: '320px', flexShrink: 0 }}>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              sx={{
+                width: '100%',
+                bgcolor: 'rgba(255,255,255,0.5)',
+                color: 'black',
+                border: '2px dashed #ccc',
+                borderRadius: '12px',
+                p: 2,
+                justifyContent: 'flex-start',
+                textTransform: 'none',
+                fontWeight: 'bold',
+                boxShadow: 'none',
+                '&:hover': { bgcolor: '#fff', borderColor: 'black' }
+              }}
+            >
+              Add New Column
+            </Button>
+          </Box>
+
+        </Box>
+      </DragDropContext>
+    </Container>
   );
-}
+};
+
+export default BoardViewPage;

--- a/frontend/src/pages/BoardsList.jsx
+++ b/frontend/src/pages/BoardsList.jsx
@@ -1,276 +1,42 @@
-import React, { useState, useEffect } from 'react';
-import { 
-  Box, 
-  Card, 
-  CardContent, 
-  Typography, 
-  Button, 
-  Container,
-  Skeleton,
-  Chip,
-  IconButton,
-  Stack
-} from '@mui/material';
-import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
-import AddIcon from '@mui/icons-material/Add';
-import DashboardIcon from '@mui/icons-material/Dashboard';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import React from 'react';
+import { Container, Grid, Card, CardContent, Typography, Box } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 
-// --- MOCK DATA ---
-const MOCK_DATA = [
-  { 
-    id: 'board-1', 
-    title: 'Marketing Campaign', 
-    status: 'Planning', 
-    color: '#00b0ff',
-    items: [
-      { id: 'task-1', content: 'Draft social media copy', priority: 'High', due: '2 days' },
-      { id: 'task-2', content: 'Select stock images', priority: 'Medium', due: '4 days' }
-    ]
-  },
-  { 
-    id: 'board-2', 
-    title: 'Design System', 
-    status: 'In Progress', 
-    color: '#00c853',
-    items: [
-      { id: 'task-3', content: 'Update button components', priority: 'High', due: 'Today' },
-      { id: 'task-4', content: 'Review typography scale', priority: 'Low', due: '1 week' },
-      { id: 'task-5', content: 'Fix mobile responsiveness', priority: 'High', due: 'Tomorrow' }
-    ]
-  },
-  { 
-    id: 'board-3', 
-    title: 'Tasky Roadmap', 
-    status: 'Active', 
-    color: '#6200ea',
-    items: [] 
-  },
+const mockBoards = [
+  { id: 1, title: 'Project Alpha', desc: 'Main development board' },
+  { id: 2, title: 'Marketing Launch', desc: 'Q4 Marketing Tasks' },
+  { id: 3, title: 'Personal Tasks', desc: 'Grocery and Gym' },
 ];
 
-// --- 1. NEW: PRIORITY COLOR MAP ---
-const PRIORITY_STYLES = {
-  High: { color: '#d32f2f', bgcolor: '#ffebee' },    // Red
-  Medium: { color: '#ed6c02', bgcolor: '#fff3e0' },  // Orange
-  Low: { color: '#2e7d32', bgcolor: '#e8f5e9' }      // Green
-};
-
-const BoardsPage = () => {
-  const [columns, setColumns] = useState([]);
-  const [loading, setLoading] = useState(true);
+const BoardsList = () => {
   const navigate = useNavigate();
 
-  useEffect(() => {
-    setTimeout(() => {
-      setColumns(MOCK_DATA); 
-      setLoading(false);
-    }, 1500); 
-  }, []);
-
-  const onDragEnd = (result) => {
-    if (!result.destination) return; 
-
-    const { source, destination } = result;
-
-    const sourceColIndex = columns.findIndex(col => col.id === source.droppableId);
-    const destColIndex = columns.findIndex(col => col.id === destination.droppableId);
-    
-    const sourceCol = columns[sourceColIndex];
-    const destCol = columns[destColIndex];
-
-    const sourceItems = [...sourceCol.items];
-    const destItems = [...destCol.items];
-
-    const [removed] = sourceItems.splice(source.index, 1);
-
-    if (source.droppableId === destination.droppableId) {
-      sourceItems.splice(destination.index, 0, removed);
-      const newColumns = [...columns];
-      newColumns[sourceColIndex] = { ...sourceCol, items: sourceItems };
-      setColumns(newColumns);
-    } else {
-      destItems.splice(destination.index, 0, removed);
-      const newColumns = [...columns];
-      newColumns[sourceColIndex] = { ...sourceCol, items: sourceItems };
-      newColumns[destColIndex] = { ...destCol, items: destItems };
-      setColumns(newColumns);
-    }
-  };
-
-  if (loading) {
-    return (
-      <Container maxWidth={false} sx={{ mt: 4, px: 4 }}>
-        <Box mb={4}><Skeleton variant="rectangular" width={200} height={40} /></Box>
-        <Box display="flex" gap={3} overflow="hidden">
-          {[1, 2, 3].map((item) => (
-            <Skeleton key={item} variant="rectangular" width={320} height={400} sx={{ borderRadius: 3, flexShrink: 0 }} />
-          ))}
-        </Box>
-      </Container>
-    );
-  }
-
   return (
-    <Container maxWidth={false} sx={{ mt: 4, mb: 8, height: '85vh', display: 'flex', flexDirection: 'column' }}>
-      
-      <Box mb={3}>
-        <Typography variant="h4" fontWeight="800" sx={{ letterSpacing: '-1px' }}>
-          My Boards
-        </Typography>
-      </Box>
-
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Box 
-          sx={{ 
-            display: 'flex', 
-            gap: 3, 
-            overflowX: 'auto', 
-            pb: 2, 
-            height: '100%',
-            alignItems: 'flex-start',
-            '&::-webkit-scrollbar': { height: '8px' },
-            '&::-webkit-scrollbar-track': { background: '#f1f1f1' },
-            '&::-webkit-scrollbar-thumb': { background: '#ccc', borderRadius: '4px' },
-          }}
-        >
-          {columns.map((column) => (
-            <Box 
-              key={column.id}
-              sx={{ 
-                minWidth: '320px', 
-                maxWidth: '320px', 
-                bgcolor: '#f4f5f7', 
-                borderRadius: '12px', 
-                p: 2,
-                flexShrink: 0,
-                display: 'flex',
-                flexDirection: 'column',
-                maxHeight: '100%'
-              }}
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h4" fontWeight="bold" gutterBottom>
+        My Boards
+      </Typography>
+      <Grid container spacing={3}>
+        {mockBoards.map((board) => (
+          <Grid item xs={12} sm={6} md={4} key={board.id}>
+            <Card 
+              sx={{ cursor: 'pointer', height: '100%', '&:hover': { boxShadow: 6 } }}
+              onClick={() => navigate(`/board/${board.id}`)}
             >
-              <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                <Box display="flex" alignItems="center" gap={1}>
-                  <Typography fontWeight="bold" variant="subtitle1">{column.title}</Typography>
-                  <Chip 
-                    label={column.items.length} 
-                    size="small" 
-                    sx={{ height: 20, fontSize: '0.7rem', fontWeight: 'bold', bgcolor: 'rgba(0,0,0,0.08)' }} 
-                  />
-                </Box>
-                <IconButton size="small"><MoreVertIcon fontSize="small" /></IconButton>
-              </Box>
-
-              <Droppable droppableId={column.id}>
-                {(provided, snapshot) => (
-                  <Box
-                    ref={provided.innerRef}
-                    {...provided.droppableProps}
-                    sx={{ 
-                      flexGrow: 1, 
-                      minHeight: '100px',
-                      transition: 'background-color 0.2s ease',
-                      bgcolor: snapshot.isDraggingOver ? 'rgba(0,0,0,0.05)' : 'transparent',
-                      borderRadius: '8px'
-                    }}
-                  >
-                    {column.items.map((task, index) => (
-                      <Draggable key={task.id} draggableId={task.id} index={index}>
-                        {(provided, snapshot) => (
-                          <Card 
-                            ref={provided.innerRef}
-                            {...provided.draggableProps}
-                            {...provided.dragHandleProps}
-                            onClick={() => navigate(`/task/${task.id}`)}
-                            sx={{ 
-                              mb: 2, 
-                              borderRadius: '8px', 
-                              boxShadow: snapshot.isDragging ? '0 10px 20px rgba(0,0,0,0.15)' : '0 1px 3px rgba(0,0,0,0.12)',
-                              cursor: 'grab',
-                              transition: 'transform 0.2s',
-                              transform: snapshot.isDragging ? 'rotate(3deg)' : 'none',
-                              '&:hover': { boxShadow: '0 4px 8px rgba(0,0,0,0.1)' }
-                            }}
-                          >
-                            <CardContent sx={{ p: '16px !important' }}>
-                              <Typography variant="body2" fontWeight="600" gutterBottom>
-                                {task.content}
-                              </Typography>
-                              
-                              <Stack direction="row" justifyContent="space-between" alignItems="center" mt={1}>
-                                
-                                {/* --- 2. UPDATED CHIP LOGIC HERE --- */}
-                                <Chip 
-                                  label={task.priority} 
-                                  size="small" 
-                                  sx={{ 
-                                    height: '20px', 
-                                    fontSize: '0.65rem', 
-                                    fontWeight: 'bold',
-                                    color: PRIORITY_STYLES[task.priority]?.color || 'grey',
-                                    bgcolor: PRIORITY_STYLES[task.priority]?.bgcolor || '#f5f5f5'
-                                  }} 
-                                />
-
-                                <Typography variant="caption" color="text.secondary" display="flex" alignItems="center">
-                                  <AccessTimeIcon sx={{ fontSize: 14, mr: 0.5 }} />
-                                  {task.due}
-                                </Typography>
-                              </Stack>
-                            </CardContent>
-                          </Card>
-                        )}
-                      </Draggable>
-                    ))}
-                    {provided.placeholder}
-                  </Box>
-                )}
-              </Droppable>
-
-              <Button 
-                startIcon={<AddIcon />} 
-                fullWidth
-                sx={{ 
-                  justifyContent: 'flex-start', 
-                  color: 'text.secondary', 
-                  textTransform: 'none',
-                  mt: 1,
-                  '&:hover': { bgcolor: 'rgba(0,0,0,0.05)', color: 'black' } 
-                }}
-              >
-                Add a task
-              </Button>
-
-            </Box>
-          ))}
-
-          <Box sx={{ minWidth: '320px', flexShrink: 0 }}>
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              sx={{
-                width: '100%',
-                bgcolor: 'rgba(255,255,255,0.5)',
-                color: 'black',
-                border: '2px dashed #ccc',
-                borderRadius: '12px',
-                p: 2,
-                justifyContent: 'flex-start',
-                textTransform: 'none',
-                fontWeight: 'bold',
-                boxShadow: 'none',
-                '&:hover': { bgcolor: '#fff', borderColor: 'black' }
-              }}
-            >
-              Add New Column
-            </Button>
-          </Box>
-
-        </Box>
-      </DragDropContext>
+              <CardContent>
+                <Typography variant="h6" fontWeight="bold">
+                  {board.title}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {board.desc}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
     </Container>
   );
 };
 
-export default BoardsPage;
+export default BoardsList;


### PR DESCRIPTION
### Summary
Separated the "Dashboard" view from the "Board" view. This completes the layout structure required for Ticket #15.

### Changes
Moved the Kanban board and drag-and-drop logic from `BoardsList.jsx` to the new `BoardViewPage.jsx` component.
- **New Feature:** Updated `BoardsList.jsx` to act as a dashboard displaying a grid of available boards (using mock data).
- **Routing:** Updated `App.jsx` to handle navigation:
  - `/boards` -> Loads the dashboard (Board List).
  - `/board/:id` -> Loads the specific Kanban board (Board View).
- **Cleanup:** Renamed components to match their file names and purpose.

### Related Ticket
Closes #15